### PR TITLE
Updated for 11.x including small changes

### DIFF
--- a/UI.lua
+++ b/UI.lua
@@ -2357,7 +2357,9 @@ function Minimap:Enable()
         MinimapCluster.BorderTop,
         MinimapCluster.Tracking,
         MinimapCluster.ZoneTextButton,
+        MinimapCluster.InstanceDifficulty,
         TimeManagerClockButton,
+        AddonCompartmentFrame,
         GameTimeFrame
     }
 

--- a/UI.toc
+++ b/UI.toc
@@ -1,8 +1,8 @@
 ## Interface: 110000, 110002
 ## Title: UI
 ## Notes: Customizable World of Warcraft UI
-## Version: 1.1.2
-## Author: Alberto Beloni
+## Version: 1.2.1
+## Author: Alberto Beloni - Modified by r4cken
 ## IconTexture: Interface\AddOns\UI\Media\Icon
 ## SavedVariables: UIDB
 ## OptionalDeps: Ace3

--- a/UI.toc
+++ b/UI.toc
@@ -1,7 +1,7 @@
-## Interface: 100205
+## Interface: 110000, 110002
 ## Title: UI
 ## Notes: Customizable World of Warcraft UI
-## Version: 1.1.1
+## Version: 1.1.2
 ## Author: Alberto Beloni
 ## IconTexture: Interface\AddOns\UI\Media\Icon
 ## SavedVariables: UIDB


### PR DESCRIPTION
This PR includes

- Action bars hide/show correctly with the new spellbook (_SpellBookFrame_ -> _PlayerSpellsFrame_)
- Replaces _GetMouseFocus()_ with _GetMouseFoci()_ as the API has changed significantly
- Added minimap components that should be included in the logic that hides/shows it
- Changed the micro menu components to include _ProfessionMicroButton_, and changed _SpellbookMicroButton_ -> _PlayerSpellsMicroButton_

I've also added some lua annotations and put in some comments, fixed a few minor mistakes. Feel free to remove the line in the UI.toc about modifications being made by me.

The version number in the UI.toc file was not updated on your last release to 1.2.0 so these changes would probably make it 1.2.1